### PR TITLE
Readme Fixes

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -9,12 +9,12 @@ One of the goals of this app is to eliminate unnecessary driver distractions.  B
 
 The downloads are no longer updated.  Google stopped supporting new downloads to developer pages.  Now you must download the app from the Play Store (preferred) or Amazon App Store.  Test versions can be downloaded by joining the https://plus.google.com/u/0/communities/110152746998730594422[testers community] on g+
 
-== See the Users Manual in the Wiki Tab
-*http://code.google.com/p/a2dpvolume/wiki/Manual *
+== User Information
+The wiki is located link:wiki[here].
 
 Looking for translators.  So far this app is in US English and translated to German, Danish, and French.  If you want another language supported, post an issue to the issues list with a way to contact you or mailto:jroal@comcast.net[email me] direct.
 
-If you can't get the text message reader working, read http://code.google.com/p/a2dpvolume/wiki/Reading_SMS[this].
+If you can't get the text message reader working, read link:wiki/Reading-Messages[this].
 
 Known issue with older Samsung Galaxy S phones not capturing location.  See details http://code.google.com/p/a2dpvolume/issues/detail?id=28[here].
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -18,7 +18,11 @@ If you can't get the text message reader working, read http://code.google.com/p/
 
 Known issue with older Samsung Galaxy S phones not capturing location.  See details http://code.google.com/p/a2dpvolume/issues/detail?id=28[here].
 
-Note: Google stopped supporting downloads on this site.  Old versions are available here but all new version must come from the Play Store.  If you want to be part of the testers group to get access to alpha and beta versions, go here: [https://plus.google.com/communities/110152746998730594422 https://plus.google.com/communities/110152746998730594422].  After you join that community, become a tester using this https://play.google.com/apps/testing/a2dp.Vol[link].
+Note: Google stopped supporting downloads on this site.  
+Old versions are available here but all new version must come from the Play Store.  
+If you want to be part of the testers group to get access to alpha and beta versions, go 
+https://plus.google.com/communities/110152746998730594422[here].  
+After you join that community, become a tester using this https://play.google.com/apps/testing/a2dp.Vol[link].
 
 == Basic Install
 
@@ -73,9 +77,7 @@ If you would like to become a alpha/beta tester please join this https://plus.go
 
 Use a bar code scanner in your Android device to scan the image below.  This will find the application on the Android Market for you.
 
-image:http://jimroal.com/exe/QR.png[QR]
-
-  market://search?q=pname:a2dp.Vol 
+image:http://jimroal.com/exe/QR.png["market://search?q=pname:a2dp.Vol",link="market://search?q=pname:a2dp.Vol"]
 
 Here are a few screen shots:
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -3,18 +3,22 @@ Automatically adjusts the media volume on connect and resets on disconnect.  Thi
 
 This app has experienced scope creep now and it does much more than originally intended.  In addition to the media volume and location features, it now can automatically launch apps and shortcuts, connect to another Bluetooth device when the first device connects, and turn OFF WIFI and turn ON GPS when a device is active.  Since version 2.2.0 it can also read your text messages for you when connected to a device.  Since 2.11.0 it can also read certain notification messages. That feature can help reduce driver distraction.  A2DP Volume also works with car docks, home docks, and the headset plug.  Rather than just global features, each feature can be configured by device so you can completely customize your control.
 
-The main version of this application requires Android 4.03 or higher (2.2 or higher until version 2.11.2).  There is another version for Android 2.1 that only adjusts the media volume and capture location.  The A2.1 version is no longer updated or supported.  As soon as you get Android 2.2 or later, uninstall the A2.1 version and upgrade to the latest main app.  See the wiki entry called upgrading.
+The main version of this application requires Android 4.03 or higher (2.2 or higher until version 2.11.2).  
+There is another version for Android 2.1 that only adjusts the media volume and capture location.  
+The A2.1 version is no longer updated or supported.  As soon as you get Android 2.2 or later, 
+uninstall the A2.1 version and upgrade to the latest main app.  
+See the wiki entry called link:../../wiki/Upgrading[upgrading].
 
 One of the goals of this app is to eliminate unnecessary driver distractions.  By automatically handling certain settings and events the driver can leave the phone in a pocket or purse and keep their eyes on the road where they belong.  We have purposely not implemented several feature requests that would have required interaction while driving.
 
 The downloads are no longer updated.  Google stopped supporting new downloads to developer pages.  Now you must download the app from the Play Store (preferred) or Amazon App Store.  Test versions can be downloaded by joining the https://plus.google.com/u/0/communities/110152746998730594422[testers community] on g+
 
 == User Information
-The wiki is located link:wiki[here].
+The wiki is located link:../../wiki[here].
 
 Looking for translators.  So far this app is in US English and translated to German, Danish, and French.  If you want another language supported, post an issue to the issues list with a way to contact you or mailto:jroal@comcast.net[email me] direct.
 
-If you can't get the text message reader working, read link:wiki/Reading-Messages[this].
+If you can't get the text message reader working, read link:../../wiki/Reading-Messages[this].
 
 Known issue with older Samsung Galaxy S phones not capturing location.  See details http://code.google.com/p/a2dpvolume/issues/detail?id=28[here].
 
@@ -61,7 +65,7 @@ This project was written in Java using the Android SDK.  Parts of the project we
 == Other Details
 A2DP = Advanced Audio Distribution Profile.  It is a Bluetooth communication profile for streaming stereo audio.  
 
-This application currently only supports US English, French, and German.  I can add support for other languages if people request it.  Add an issue to the issues list for the languages you want supported.  Be prepared to help us with the translations.  If one of the non-English translations is incorrect, please enter an issue for that as well.  Here is more info on what it takes to help with http://code.google.com/p/a2dpvolume/wiki/Translations[translations].
+This application currently only supports US English, French, and German.  I can add support for other languages if people request it.  Add an issue to the issues list for the languages you want supported.  Be prepared to help us with the translations.  If one of the non-English translations is incorrect, please enter an issue for that as well.  Here is more info on what it takes to help with link:../../wiki/Translations[translations].
 
 Want an older version?  Nearly all previous versions are available for download http://code.google.com/p/a2dpvolume/downloads/list?can=1&q=&colspec=Filename+Summary+Uploaded+ReleaseDate+Size+DownloadCount[here].
 
@@ -84,7 +88,7 @@ Here are a few screen shots:
 image:http://jimroal.com/A2DPScreens/Main.png["Main",height=500] 
 image:http://jimroal.com/A2DPScreens/EditDevice.png["Edit Device",height=500,float="left"]
 
-Click http://code.google.com/p/a2dpvolume/wiki/ScreenShots[here]
+Click link:../../wiki/ScreenShots[here]
 for more screen shots.
 
 Click http://www.youtube.com/watch?v=3sy_pCbJHA0&list=PL8B87E2415E38D95E&feature=plpp_play_all[here] for the video.

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -21,13 +21,14 @@ Known issue with older Samsung Galaxy S phones not capturing location.  See deta
 Note: Google stopped supporting downloads on this site.  Old versions are available here but all new version must come from the Play Store.  If you want to be part of the testers group to get access to alpha and beta versions, go here: [https://plus.google.com/communities/110152746998730594422 https://plus.google.com/communities/110152746998730594422].  After you join that community, become a tester using this https://play.google.com/apps/testing/a2dp.Vol[link].
 
 == Basic Install
- # Pair device using the Android settings screen.  {{{[menu key] -> [Settings] -> [Wireless & networks] -> [Bluetooth settings] -> [Scan for devices]}}}.  Your device will need to show connected on this screen.  Here is a video explaining it: http://www.youtube.com/watch?v=8-wuRA9I0RM .  
- # Install my app from the Android Market or this website. 
- # In my app, click {{{[Find Devices]}}}.  This should return a list of paired Bluetooth devices.  Your Bluetooth will need to be ON for this to work.  That means the Bluetooth symbol should be in the status bar area.  If it is not ON this app will attempt to turn it ON when finding devices.  If you plan to use this app with home dock, car dock, or the audio jack, you need to first select that in the preferences.  See manual for details.
- # Select each Bluetooth device from the list in my app.  Short click on the device in the list will open a dialog box so you can configure it.  
- # Click the {{{[Edit]}}} (center button) and you can now edit the specific settings for the Bluetooth device.  Here is where you set options you want for this specific device.  See the manual for more details. 
- # Click the {{{[Save]}}} button when complete. 
- # Back at the main menu in my app, you should see the right button now says "Stop Service".  That means the app is ready to adjust volume and capture location data.  If you were already connected to the Bluetooth device when you installed and configured my app then you will need to disconnect and reconnect for it to trigger the volume and location capture.  
+
+. Pair device using the Android settings screen.  +[menu key] -> [Settings] -> [Wireless & networks] -> [Bluetooth settings] -> [Scan for devices]+.  Your device will need to show connected on this screen.  http://www.youtube.com/watch?v=8-wuRA9I0RM[Here] is a video explaining it.  
+. Install my app from the Android Market or this website. 
+. In my app, click +[Find Devices]+.  This should return a list of paired Bluetooth devices.  Your Bluetooth will need to be ON for this to work.  That means the Bluetooth symbol should be in the status bar area.  If it is not ON this app will attempt to turn it ON when finding devices.  If you plan to use this app with home dock, car dock, or the audio jack, you need to first select that in the preferences.  See manual for details.
+. Select each Bluetooth device from the list in my app.  Short click on the device in the list will open a dialog box so you can configure it.  
+. Click the +[Edit]+ (center button) and you can now edit the specific settings for the Bluetooth device.  Here is where you set options you want for this specific device.  See the manual for more details. 
+. Click the +[Save]+ button when complete. 
+. Back at the main menu in my app, you should see the right button now says "Stop Service".  That means the app is ready to adjust volume and capture location data.  If you were already connected to the Bluetooth device when you installed and configured my app then you will need to disconnect and reconnect for it to trigger the volume and location capture.  
 
 
 If you can read software code, look in the "source" tab above.  You can use the 
@@ -40,6 +41,7 @@ Please submit any bug reports or ideas for future enhancements in the issues lis
 You can name each Bluetooth device with a more meaningful name.  Android native gets the device name from the remote device and does not let you rename it (until Android 4.0 and up).  If you have more than one of those devices, they all look the same in Android.
 
 Allows you to configure each device separately to:  
+
   * Capture location on disconnect. Triggers a GPS listener to capture the most accurate location.  If a GPS location of a configurable accuracy is not found in a configurable amount of time, it turns the listener back OFF to save your battery.
   * Adjust media volume on connect, restore on disconnect
   * Adjust phone in-call volume on connect, restore on disconnect

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -73,21 +73,22 @@ If you would like to become a alpha/beta tester please join this https://plus.go
 
 Use a bar code scanner in your Android device to scan the image below.  This will find the application on the Android Market for you.
 
-http://jimroal.com/exe/QR.png
+image:http://jimroal.com/exe/QR.png[QR]
 
   market://search?q=pname:a2dp.Vol 
 
-Here are a few screen shots
- ||http://jimroal.com/A2DPScreens/Main.png || http://jimroal.com/A2DPScreens/EditDevice.png ||
+Here are a few screen shots:
 
-Click here
-http://code.google.com/p/a2dpvolume/wiki/ScreenShots
+image:http://jimroal.com/A2DPScreens/Main.png["Main",height=500] 
+image:http://jimroal.com/A2DPScreens/EditDevice.png["Edit Device",height=500,float="left"]
+
+Click http://code.google.com/p/a2dpvolume/wiki/ScreenShots[here]
 for more screen shots.
 
-Click here for the video:
-http://www.youtube.com/watch?v=3sy_pCbJHA0&list=PL8B87E2415E38D95E&feature=plpp_play_all
+Click http://www.youtube.com/watch?v=3sy_pCbJHA0&list=PL8B87E2415E38D95E&feature=plpp_play_all[here] for the video.
 
-Here is the app on the Google Play Store:
-https://market.android.com/details?id=a2dp.Vol&feature=search_result
+
+You can find the app on the Google Play Store 
+https://market.android.com/details?id=a2dp.Vol&feature=search_result[here].
 
 I created a simple tester app that can be used to invoke Car Mode and for sending text strings to A2DP Volume simulating a message from an app.  You can get it http://jimroal.com/exe/CarMode1_1.apk[here] or in downloads http://code.google.com/p/a2dpvolume/downloads/detail?name=CarMode1_1.apk[here].

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,4 +1,4 @@
-= Overview =
+= Overview
 Automatically adjusts the media volume on connect and resets on disconnect.  This is done so the stereo streaming audio will work properly.  Intended primarily for car Bluetooth systems.  Also automatically captures location information so you can find where you left your car.  The location can also be automatically captured when exiting Car Mode on your Android device.  The location can be read by any app that understands GPS data such as Google Maps, GPS Status, web browsers, etc.  A2DP Volume version 2.2.0 and above can also read out text messages using Text To Speech (TTS) services while you are connected. Each paired Bluetooth device or virtual device (home dock, car dock, power connection, or headset plug) can be configured to your liking. 
 
 This app has experienced scope creep now and it does much more than originally intended.  In addition to the media volume and location features, it now can automatically launch apps and shortcuts, connect to another Bluetooth device when the first device connects, and turn OFF WIFI and turn ON GPS when a device is active.  Since version 2.2.0 it can also read your text messages for you when connected to a device.  Since 2.11.0 it can also read certain notification messages. That feature can help reduce driver distraction.  A2DP Volume also works with car docks, home docks, and the headset plug.  Rather than just global features, each feature can be configured by device so you can completely customize your control.
@@ -7,22 +7,20 @@ The main version of this application requires Android 4.03 or higher (2.2 or hig
 
 One of the goals of this app is to eliminate unnecessary driver distractions.  By automatically handling certain settings and events the driver can leave the phone in a pocket or purse and keep their eyes on the road where they belong.  We have purposely not implemented several feature requests that would have required interaction while driving.
 
-The downloads are no longer updated.  Google stopped supporting new downloads to developer pages.  Now you must download the app from the Play Store (preferred) or Amazon App Store.  Test versions can be downloaded by joining the [https://plus.google.com/u/0/communities/110152746998730594422 testers community] on g+
+The downloads are no longer updated.  Google stopped supporting new downloads to developer pages.  Now you must download the app from the Play Store (preferred) or Amazon App Store.  Test versions can be downloaded by joining the https://plus.google.com/u/0/communities/110152746998730594422[testers community] on g+
 
-== See the Users Manual in the Wiki Tab ==
+== See the Users Manual in the Wiki Tab
 *http://code.google.com/p/a2dpvolume/wiki/Manual *
 
-Looking for translators.  So far this app is in US English and translated to German, Danish, and French.  If you want another language supported, post an issue to the issues list with a way to contact you or email [mailto:jroal@comcast.net me] direct.
+Looking for translators.  So far this app is in US English and translated to German, Danish, and French.  If you want another language supported, post an issue to the issues list with a way to contact you or mailto:jroal@comcast.net[email me] direct.
 
-If you can't get the text message reader working, read this: 
-http://code.google.com/p/a2dpvolume/wiki/Reading_SMS
+If you can't get the text message reader working, read http://code.google.com/p/a2dpvolume/wiki/Reading_SMS[this].
 
-Known issue with older Samsung Galaxy S phones not capturing location.  See details here: 
-http://code.google.com/p/a2dpvolume/issues/detail?id=28
+Known issue with older Samsung Galaxy S phones not capturing location.  See details http://code.google.com/p/a2dpvolume/issues/detail?id=28[here].
 
-Note: Google stopped supporting downloads on this site.  Old versions are available here but all new version must come from the Play Store.  If you want to be part of the testers group to get access to alpha and beta versions, go here: [https://plus.google.com/communities/110152746998730594422 https://plus.google.com/communities/110152746998730594422].  After you join that community, become a tester using this link[https://play.google.com/apps/testing/a2dp.Vol https://play.google.com/apps/testing/a2dp.Vol].
+Note: Google stopped supporting downloads on this site.  Old versions are available here but all new version must come from the Play Store.  If you want to be part of the testers group to get access to alpha and beta versions, go here: [https://plus.google.com/communities/110152746998730594422 https://plus.google.com/communities/110152746998730594422].  After you join that community, become a tester using this https://play.google.com/apps/testing/a2dp.Vol[link].
 
-== Basic Install ==
+== Basic Install
  # Pair device using the Android settings screen.  {{{[menu key] -> [Settings] -> [Wireless & networks] -> [Bluetooth settings] -> [Scan for devices]}}}.  Your device will need to show connected on this screen.  Here is a video explaining it: http://www.youtube.com/watch?v=8-wuRA9I0RM .  
  # Install my app from the Android Market or this website. 
  # In my app, click {{{[Find Devices]}}}.  This should return a list of paired Bluetooth devices.  Your Bluetooth will need to be ON for this to work.  That means the Bluetooth symbol should be in the status bar area.  If it is not ON this app will attempt to turn it ON when finding devices.  If you plan to use this app with home dock, car dock, or the audio jack, you need to first select that in the preferences.  See manual for details.
@@ -33,12 +31,12 @@ Note: Google stopped supporting downloads on this site.  Old versions are availa
 
 
 If you can read software code, look in the "source" tab above.  You can use the 
-[http://code.google.com/p/a2dpvolume/source/browse/ browse function] to view the source code in your browser.  The project was written in Java using Eclipse and the Android SDK.
+http://code.google.com/p/a2dpvolume/source/browse/[browse function] to view the source code in your browser.  The project was written in Java using Eclipse and the Android SDK.
 
-=Issues=
+= Issues
 Please submit any bug reports or ideas for future enhancements in the issues list (issues tab above).  Before submitting a new issue, make sure your issues does not already exists on that list.  If it does, you can add comments and star it so you are informed of updates.  Also, please submit error reports if you experience a crash.  Android automates this for you.  When most crashes happen Android provides a dialog that allows you to either force close or report.  Please report.  These reports tell me what happened so I can fix it.
 
-= Additional Features =
+= Additional Features
 You can name each Bluetooth device with a more meaningful name.  Android native gets the device name from the remote device and does not let you rename it (until Android 4.0 and up).  If you have more than one of those devices, they all look the same in Android.
 
 Allows you to configure each device separately to:  
@@ -54,14 +52,14 @@ Allows you to configure each device separately to:
 
 This project was written in Java using the Android SDK.  Parts of the project were leveraged from examples or other open source applications.
 
-==Other Details==
+== Other Details
 A2DP = Advanced Audio Distribution Profile.  It is a Bluetooth communication profile for streaming stereo audio.  
 
-This application currently only supports US English, French, and German.  I can add support for other languages if people request it.  Add an issue to the issues list for the languages you want supported.  Be prepared to help us with the translations.  If one of the non-English translations is incorrect, please enter an issue for that as well.  Here is more info on what it takes to help with translations: http://code.google.com/p/a2dpvolume/wiki/Translations
+This application currently only supports US English, French, and German.  I can add support for other languages if people request it.  Add an issue to the issues list for the languages you want supported.  Be prepared to help us with the translations.  If one of the non-English translations is incorrect, please enter an issue for that as well.  Here is more info on what it takes to help with http://code.google.com/p/a2dpvolume/wiki/Translations[translations].
 
-Want an older version?  Nearly all previous versions are available for download [http://code.google.com/p/a2dpvolume/downloads/list?can=1&q=&colspec=Filename+Summary+Uploaded+ReleaseDate+Size+DownloadCount here].
+Want an older version?  Nearly all previous versions are available for download http://code.google.com/p/a2dpvolume/downloads/list?can=1&q=&colspec=Filename+Summary+Uploaded+ReleaseDate+Size+DownloadCount[here].
 
-Why do we create this app for free with no ads?  Good question.  I was really not sure for the longest time until this [http://www.youtube.com/watch?v=tJr9QajdCNc video explained it].  The only donation we would like is good ratings and comments on Google Play Store.  If you can participate in coding, testing, translating, etc we would welcome that help too.  Also, please spread the word to help promote this app.
+Why do we create this app for free with no ads?  Good question.  I was really not sure for the longest time until this http://www.youtube.com/watch?v=tJr9QajdCNc[video explained it].  The only donation we would like is good ratings and comments on Google Play Store.  If you can participate in coding, testing, translating, etc we would welcome that help too.  Also, please spread the word to help promote this app.
 
 Note:  This application was made available in Android Market starting with version 1.2.1. October 30, 2010. 
 
@@ -69,7 +67,7 @@ No warranties or liabilities expressed or implied.  This is a free open source p
 
 There are clones being sold on the Play Store.  At least one of these is charging for an older version.  Avoid these scams!
 
-If you would like to become a alpha/beta tester please join this group: https://plus.google.com/u/0/communities/110152746998730594422
+If you would like to become a alpha/beta tester please join this https://plus.google.com/u/0/communities/110152746998730594422[group].
 
 Use a bar code scanner in your Android device to scan the image below.  This will find the application on the Android Market for you.
 
@@ -90,4 +88,4 @@ http://www.youtube.com/watch?v=3sy_pCbJHA0&list=PL8B87E2415E38D95E&feature=plpp_
 Here is the app on the Google Play Store:
 https://market.android.com/details?id=a2dp.Vol&feature=search_result
 
-I created a simple tester app that can be used to invoke Car Mode and for sending text strings to A2DP Volume simulating a message from an app.  You can get it here: http://jimroal.com/exe/CarMode1_1.apk or in downloads here: http://code.google.com/p/a2dpvolume/downloads/detail?name=CarMode1_1.apk
+I created a simple tester app that can be used to invoke Car Mode and for sending text strings to A2DP Volume simulating a message from an app.  You can get it http://jimroal.com/exe/CarMode1_1.apk[here] or in downloads http://code.google.com/p/a2dpvolume/downloads/detail?name=CarMode1_1.apk[here].


### PR DESCRIPTION
The readme is pretty much up to date now.

* There are some links that still point to https://code.google.com/p/a2dpvolume/. 
   I am not sure where the binaries are going to be on under GitHub.
* The link to Previous versions still points to https://code.google.com/p/a2dpvolume/. 
* Is "Known issue with older Samsung Galaxy S phones not capturing location"
   really true anymore? The issue seems closed, but the warning remains.
* The browse source link still points to Google Code.
  I don't think that this area makes much sense in GitHub: It needs a more extensive 
  rewrite.