### PR TITLE
Android automatic refactor - Recycle

### DIFF
--- a/app/src/main/java/a2dp/Vol/DataXmlExporter.java
+++ b/app/src/main/java/a2dp/Vol/DataXmlExporter.java
@@ -69,6 +69,9 @@ public class DataXmlExporter {
 				}
 			} while (c.moveToNext());
 		}
+		if (c != null) {
+			c.close();
+		}
 		String xmlString = this.xmlBuilder.end();
 		try {
 			this.writeToFile(xmlString, exportFileNamePrefix + ".xml");

--- a/app/src/main/java/a2dp/Vol/service.java
+++ b/app/src/main/java/a2dp/Vol/service.java
@@ -1622,6 +1622,9 @@ public class service extends Service implements OnAudioFocusChangeListener {
                         .getColumnIndex(PhoneLookup.DISPLAY_NAME));
                 return name;
             }
+			if (c != null) {
+				c.close();
+			}
         }
         return number;
     }


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "Recycle".

Some resources (e.g., ```Cursor``` instances) should be closed when they are no longer necessary. 

I have made a previous validation of the changes and they seem correct.
Please consider them and let me know if you agree with them.

Best,
Luis