### PR TITLE
Refactor Internal Setter smell in AppInfoCache class

### DIFF
--- a/a2dpvolume.iml
+++ b/a2dpvolume.iml
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="a2dpvolume" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
-    <facet type="java-gradle" name="Java-Gradle">
+    <facet type="android-gradle" name="Android-Gradle">
       <configuration>
-        <option name="BUILD_FOLDER_PATH" value="$MODULE_DIR$/build" />
-        <option name="BUILDABLE" value="false" />
+        <option name="GRADLE_PROJECT_PATH" value=":" />
+        <option name="LAST_SUCCESSFUL_SYNC_AGP_VERSION" />
+        <option name="LAST_KNOWN_AGP_VERSION" />
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="true">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
-    <content url="file://$MODULE_DIR$">
-      <excludeFolder url="file://$MODULE_DIR$/.gradle" />
-    </content>
+    <content url="file://$MODULE_DIR$" />
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>

--- a/app/src/main/java/a2dp/Vol/PackagesChooser.java
+++ b/app/src/main/java/a2dp/Vol/PackagesChooser.java
@@ -197,7 +197,7 @@ public class PackagesChooser extends Activity {
             package_name = pName;
             class_name = cName;
             position = -1;
-            setChecked(false);
+            this.checked = false;
         }
 
         public Drawable getIcon() {


### PR DESCRIPTION
Hi, I'm Emanuele Iannone, a master student at University of Salerno.
Since my bachelor's thesis I have been working on a **code smell refactoring plugin** called *aDoctor*, which is able to identify and fix energy-related problems in Android apps.
I launched it on your project, finding different instances of code smells. I chose one of them and let the plugin automatically fix it.
In this case I chose Internal Setter, that is present when non static method calls a setter method of an instance variable instead of directly changing its value. These kind of smell may have a non trivial impact on energy consumption, as shown in this paper: `https://www.sciencedirect.com/science/article/pii/S0950584918301678`.
Besides, this kind of refactoring does not impact on the functionalities of your app, so it is totally safe. Let me know if you are interested in this refactoring proposal.