### PR TITLE
solve issue of low contrast

### DIFF
--- a/app/src/main/res/layout/app_list_item.xml
+++ b/app/src/main/res/layout/app_list_item.xml
@@ -8,6 +8,7 @@
     <TextView
         android:id="@+id/pi_tv_name"
         android:layout_width="0dp"
+        android:textColor="#727272"     
         android:layout_height="fill_parent"
         android:layout_weight="1"
         android:gravity="center_vertical"

--- a/app/src/main/res/layout/package_list_item.xml
+++ b/app/src/main/res/layout/package_list_item.xml
@@ -9,6 +9,7 @@
     <TextView
         android:id="@+id/pi_tv_name"
         android:layout_width="0dp"
+        android:textColor="#727272"
         android:layout_height="fill_parent"
         android:layout_weight="1"
         android:gravity="center_vertical"


### PR DESCRIPTION
The original text color of the component is '#FAFAFA', and the contrast between the text color ('#FAFAFA') and the background color ('#FFFFFF') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#737373') are as follows:
![image](https://user-images.githubusercontent.com/101503193/211215633-7e992956-0c36-41cf-9fe8-67ac63742cd1.png)
The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.